### PR TITLE
Updating `tersmitten` deps to `Oefenweb`, as per:

### DIFF
--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -1,7 +1,7 @@
 ---
-- src: tersmitten.ntp
+- src: Oefenweb.ntp
   version: v1.0.2
 - src: adriagalin.timezone
   version: 1.0.1
-- src: tersmitten.locales
+- src: Oefenweb.locales
   version: v1.0.3

--- a/provisioning/roles/preservicaservice/README.md
+++ b/provisioning/roles/preservicaservice/README.md
@@ -80,4 +80,3 @@ Propriate
 
 Author Information
 ------------------
-

--- a/provisioning/roles/preservicaservice/README.md
+++ b/provisioning/roles/preservicaservice/README.md
@@ -80,3 +80,4 @@ Propriate
 
 Author Information
 ------------------
+

--- a/provisioning/roles/preservicaservice/README.md
+++ b/provisioning/roles/preservicaservice/README.md
@@ -56,14 +56,14 @@ Role Variables
 Dependencies
 ------------
 
-    - role: tersmitten.locales
+    - role: Oefenweb.locales
     locales_present:
       - en_US.UTF-8
     locales_default:
       lang: en_US.UTF-8
     - role: adriagalin.timezone
     ag_timezone: Etc/UTC
-    - tersmitten.ntp
+    - Oefenweb.ntp
 
 
 Example Playbook

--- a/provisioning/roles/preservicaservice/meta/main.yml
+++ b/provisioning/roles/preservicaservice/meta/main.yml
@@ -11,6 +11,6 @@ galaxy_info:
      - xenial
 
 dependencies:
-  - { role: tersmitten.locales, locales_present: 'en_US.UTF-8', locales_default: { lang: en_US.UTF-8 } }
+  - { role: Oefenweb.locales, locales_present: 'en_US.UTF-8', locales_default: { lang: en_US.UTF-8 } }
   - { role: adriagalin.timezone, ag_timezone: Etc/UTC }
-  - { role: tersmitten.ntp }
+  - { role: Oefenweb.ntp }


### PR DESCRIPTION
tersmitten has changed to to Oefenweb on ansible galaxy, so builds are failing without this update. 
v. https://github.com/roots/trellis/issues/1011