### PR TITLE
Feature/rdss 2178 raise http errors on download

### DIFF
--- a/preservicaservice/remote_urls.py
+++ b/preservicaservice/remote_urls.py
@@ -111,6 +111,7 @@ class HTTPRemoteUrl(BaseRemoteUrl):
         """ Download remote file via HTTP to the provided download path."""
         try:
             r = requests.get(self.url, stream=True)
+            r.raise_for_status()
             with open(download_path, 'wb') as f:
                 for chunk in r.iter_content(chunk_size=1024):
                     if chunk:


### PR DESCRIPTION
This add's in a `raise_for_status()` call that really should have been here already to prevent the adaptor downloading an error body response and calling it a file. 